### PR TITLE
Add Dockerfile and Github Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: ci
+
+on:
+  push:
+    branches:    # only for pushes on master
+    - master
+  pull_request:  # for all PRs regardless of its base branch
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build the Docker image
+      run: docker build -t amino-js:$(git rev-parse HEAD) .
+
+    - name: Run unit tests
+      run: docker run -it amino-js:$(git rev-parse HEAD) yarn test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,4 +19,4 @@ jobs:
       run: docker build -t amino-js:$(git rev-parse HEAD) .
 
     - name: Run unit tests
-      run: docker run -it amino-js:$(git rev-parse HEAD) yarn test
+      run: docker run amino-js:$(git rev-parse HEAD) yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
+node_modules/
 /types

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+*       @cl9200 @youngjoon-lee

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,4 @@ RUN cd go/js && go mod download
 RUN yarn install
 RUN yarn setup
 
-RUN yarn test
-
 CMD ["yarn", "pack"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM golang:1.12-stretch AS build-stage
+
+# Install node.js 14
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get update && apt-get -y install nodejs
+
+# Install yarn
+RUN apt-get update && apt-get install -y apt-transport-https
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get -y install yarn
+
+# Install myitcv/gopherjs
+RUN git clone https://github.com/myitcv/gopherjs "/go/src/github.com/gopherjs/gopherjs" \
+    && cd "/go/src/github.com/gopherjs/gopherjs" \
+    && GO111MODULE=on go install
+
+RUN mkdir /amino-js
+WORKDIR /amino-js
+COPY . .
+
+# Install Go dependencies
+RUN cd go/lib && go mod download
+RUN cd go/extensions && go mod download
+RUN cd go/src && go mod download
+RUN cd go/js && go mod download
+
+RUN yarn install
+RUN yarn setup
+
+RUN yarn test
+
+CMD ["yarn", "pack"]

--- a/README.md
+++ b/README.md
@@ -65,3 +65,20 @@ const encodedTx = marshalTx(tx);
 const decodedTx = unmarshalTx(encodedTx);
 ```
 
+## Contribution
+
+### Build
+
+Unfortunately, [cosmos/amino-js](https://github.com/cosmos/amino-js) and [myitcv/gopherjs](https://github.com/myitcv/gopherjs) work with only Go 1.12 (not the latest Go).
+
+Therefore, it is recommended to build this project using Docker based on Go 1.12.
+```bash
+docker build -t amino-js:latest .
+```
+It just produces the artifacts which can be published to NPM, but it doesn't actually publish them.
+
+If you want to publish the new version of the package to NPM, please run the Docker container.
+(NOTE: In this case, please bump the version in the `package.json` before running `docker build`.)
+```bash
+docker run -it amino-js:latest yarn publish
+```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const decodedTx = unmarshalTx(encodedTx);
 
 Unfortunately, [cosmos/amino-js](https://github.com/cosmos/amino-js) and [myitcv/gopherjs](https://github.com/myitcv/gopherjs) work with only Go 1.12 (not the latest Go).
 
-Therefore, it is recommended to build this project using Docker based on Go 1.12.
+Therefore, it is recommended to build this project using Docker based on Go 1.12, if you don't want to change your local dev environment with the latest Go.
 ```bash
 docker build -t amino-js:latest .
 ```


### PR DESCRIPTION
1. Dockerfile
I made a Dockerfile to build this project easily, because it's painful to build amino-js and GopherJs using the latest Go.
For more details, please see README.md.

2. Github Actions
Because this repo is public, I used Github Actions which is simpler and free.